### PR TITLE
an ElmHttpIdType constructor for ElmDatatype

### DIFF
--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -30,10 +30,17 @@ instance HasDecoder ElmDatatype where
     return $
       (fnName <+> ": Decoder" <+> stext name) <$$>
       (fnName <+> "=" <$$> indent 4 ctor)
+  render d@(ElmHttpIdType name constructor _) = do
+    fnName <- renderRef d
+    ctor <- render constructor
+    return $
+      (fnName <+> ": Decoder" <+> stext name) <$$>
+      (fnName <+> "=" <$$> indent 4 ctor)
   render (ElmPrimitive primitive) = renderRef primitive
 
 instance HasDecoderRef ElmDatatype where
   renderRef (ElmDatatype name _) = pure $ "decode" <> stext name
+  renderRef (ElmHttpIdType name _ _) = pure $ "decode" <> stext name
   renderRef (ElmPrimitive primitive) = renderRef primitive
 
 instance HasDecoder ElmConstructor where

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -27,10 +27,17 @@ instance HasEncoder ElmDatatype where
     return $
       (fnName <+> ":" <+> stext name <+> "->" <+> "Json.Encode.Value") <$$>
       (fnName <+> "x =" <$$> indent 4 ctor)
+  render d@(ElmHttpIdType name constructor _) = do
+    fnName <- renderRef d
+    ctor <- render constructor
+    return $
+      (fnName <+> ":" <+> stext name <+> "->" <+> "Json.Encode.Value") <$$>
+      (fnName <+> "x =" <$$> indent 4 ctor)
   render (ElmPrimitive primitive) = renderRef primitive
 
 instance HasEncoderRef ElmDatatype where
   renderRef (ElmDatatype name _) = pure $ "encode" <> stext name
+  renderRef (ElmHttpIdType name _ _) = pure $ "encode" <> stext name
   renderRef (ElmPrimitive primitive) = renderRef primitive
 
 instance HasEncoder ElmConstructor where

--- a/src/Elm/Record.hs
+++ b/src/Elm/Record.hs
@@ -32,10 +32,19 @@ instance HasType ElmDatatype where
     name <- renderRef d
     ctor <- render constructor
     return . nest 4 $ "type" <+> name <$$> "=" <+> ctor
+  render d@(ElmHttpIdType _ constructor@(RecordConstructor _ _) _) = do
+    name <- renderRef d
+    ctor <- render constructor
+    return . nest 4 $ "type alias" <+> name <+> "=" <$$> ctor
+  render d@(ElmHttpIdType _ constructor _) = do
+    name <- renderRef d
+    ctor <- render constructor
+    return . nest 4 $ "type" <+> name <$$> "=" <+> ctor
   render (ElmPrimitive primitive) = renderRef primitive
 
 instance HasTypeRef ElmDatatype where
   renderRef (ElmDatatype typeName _) = pure (stext typeName)
+  renderRef (ElmHttpIdType typeName _ _) = pure (stext typeName)
   renderRef (ElmPrimitive primitive) = renderRef primitive
 
 instance HasType ElmConstructor where

--- a/src/Elm/Type.hs
+++ b/src/Elm/Type.hs
@@ -20,6 +20,9 @@ import Prelude
 data ElmDatatype
   = ElmDatatype Text
                 ElmConstructor
+  | ElmHttpIdType Text
+                  ElmConstructor
+                  Text
   | ElmPrimitive ElmPrimitive
   deriving (Show, Eq)
 
@@ -124,6 +127,7 @@ instance ElmType a =>
     case toElmType (Proxy :: Proxy a) of
       ElmPrimitive primitive -> ElmPrimitiveRef primitive
       ElmDatatype name _ -> ElmRef name
+      ElmHttpIdType name _ _ -> ElmRef name
 
 instance ElmType a =>
          ElmType [a] where


### PR DESCRIPTION
this is a bit of a hack, but the idea is to allow id's which are
wrapped inside of a container to be passed as url values.

to use this, override the default interface of ElmType like so:

```haskell
instance ElmType Api.WorkbookId where
    toElmType wbId = ElmHttpIdType
                        (pack "WorkbookId")
                        (RecordConstructor (pack "WorkbookId") $
                         ElmField (pack "id") $ ElmPrimitiveRef EInt )
                        (pack "id")
```

I'm doing a lot of manual work the GenericElm* does for me, but I don't
understand reflection in haskell well enough to do it properly.  In the
above example, I am saying that the "id" field of a "Api.WorkbookId"
is what goes into a url parser in servant-elm.

If the ID is a string, one should set that as an option in servant-elm.