### PR TITLE
Encodes elm dates as `UtcIso` strings.

### DIFF
--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -134,7 +134,7 @@ instance HasEncoder ElmValue where
   render _ = error "HasEncoderRef ElmValue: should not happen"
 
 instance HasEncoderRef ElmPrimitive where
-  renderRef EDate = pure $ parens "Json.Encode.string << (Date.Extra.toFormattedString \"y-MM-dd\")"
+  renderRef EDate = pure $ parens "Json.Encode.string << Date.Extra.toUtcIsoString"
   renderRef EUnit = pure "Json.Encode.null"
   renderRef EInt = pure "Json.Encode.int"
   renderRef EChar = pure "Json.Encode.char"


### PR DESCRIPTION
This is parseable in Haskell with `aeson`, for instance. https://github.com/TriviumRealEstate/excelsior/pull/480.